### PR TITLE
Add minimap showing habitat direction, position, velocity relative to reference

### DIFF
--- a/orbitx/flight_gui.py
+++ b/orbitx/flight_gui.py
@@ -58,6 +58,7 @@ class FlightGui:
         # 1) when started, the small_habitat axis is too long
         # 2) Reference arrow doesn't change when habitat spin change?
         # 3) "s" button should stop spin , and change current "s" to "x"
+        # 4) Find right location for _habitat_scene : above menus
         self._habitat_scene = vpython.canvas(width=200, height=150,
                                            center=vpython.vector(0,0,0),
                                            up=vpython.vector(0, 0, 1),

--- a/orbitx/flight_gui.py
+++ b/orbitx/flight_gui.py
@@ -54,6 +54,10 @@ class FlightGui:
                     '__factory').protocol.onClose = callback
 
         # Set up the second vpython canvas for display the unit_velocity?
+        #TODO:
+        # 1) when started, the small_habitat axis is too long
+        # 2) Reference arrow doesn't change when habitat spin change?
+        # 3) "s" button should stop spin , and change current "s" to "x"
         self._habitat_scene = vpython.canvas(width=200, height=150,
                                            center=vpython.vector(0,0,0),
                                            up=vpython.vector(0, 0, 1),

--- a/orbitx/flight_gui.py
+++ b/orbitx/flight_gui.py
@@ -510,15 +510,12 @@ class FlightGui:
                 self._habitat_trail.clear()
 
             self._small_habitat = hab_object(self._minimap_canvas)
-            arrow_length = planet.r
             self._ref_arrow = vpython.arrow(
                 canvas=self._minimap_canvas,
-                color=vpython.color.gray(0.5),
-                axis=self._posn(self._reference).norm() * arrow_length * 1.2)
+                color=vpython.color.gray(0.5))
             self._velocity_arrow = vpython.arrow(
                 canvas=self._minimap_canvas,
-                color=vpython.color.red,
-                axis=self._unit_velocity_ref(planet) * arrow_length)
+                color=vpython.color.red)
 
         else:
             obj = self._vpython.sphere(
@@ -580,12 +577,14 @@ class FlightGui:
         sphere.pos = self._posn(planet)
         sphere.axis = self._ang_pos(planet.heading)
         if planet.name == 'Habitat':
-            self._ref_arrow.axis = (
-                self._posn(self._reference).norm() *
-                self._ref_arrow.length)
-            self._velocity_arrow.axis = (
-                self._unit_velocity_ref(planet) *
-                self._velocity_arrow.length)
+            if self._reference != self._habitat:
+                self._ref_arrow.axis = (
+                    self._posn(self._reference).norm() * planet.r * 1.2)
+                self._velocity_arrow.axis = (
+                    self._unit_velocity_ref(planet).norm() * planet.r)
+            else:
+                self._ref_arrow.axis = vpython.vector(0, 0, -1)
+                self._velocity_arrow.axis = vpython.vector(0, 0, -1)
             self._small_habitat.axis = sphere.axis
             self._habitat = planet
 


### PR DESCRIPTION
Hey @sh32kim, tidied up the code. I ended up calling the vector box scene the 'minimap', and putting the minimap at the bottom of the caption. It's pretty finicky to put it in the middle, so I gave up. And IRL minimaps are usually in the bottom left anyway, right?

I also changed the arrows to show the velocity and direction to the reference, instead of velocity relative to reference and target, since that's what the old program did.

Once @goodday0404 and I are able to finish our work on refactoring the flight_gui code, we'll also refactor the one or two calculations we added in this PR (sorry that they interfere with the refactor!)

I'm also expecting a pep8 error on the '\_\_init__' line and in three other comment lines, but I won't fix that because then we'll get more merge conflicts with the code quality refactor.